### PR TITLE
Fix QBCore nil value

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,6 +4,9 @@ game 'gta5'
 description 'QB-Justice'
 version '1.0.0'
 
-shared_script '@qb-core/import.lua'
+shared_scripts { 
+	'@qb-core/import.lua'
+}
+
 client_script 'client/main.lua'
 server_script 'server/main.lua'


### PR DESCRIPTION
just noticed that in order to make shared import.lua work, a "{ }" is required. not sure if you guys have the same problem tho